### PR TITLE
fix compressed file gets deleted if origin file shrinks below MIN_SIZE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 django_static_compress.egg-info/
 __pycache__
 .vscode
+.venv*
+.eggs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
 exclude: integration_test/statictest/static/
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks.git
-  sha: v1.4.0
-  hooks:
-  - id: check-added-large-files
-  - id: check-ast
-  - id: check-case-conflict
-  - id: check-merge-conflict
-  - id: check-symlinks
-- repo: https://github.com/ambv/black.git
-  sha: 18.6b4
-  hooks:
-  - id: black
-    entry: black -l 120 --py36
-- repo: local
-  hooks:
-  - id: pylint
-    name: pylint
-    entry: pylint
-    language: system
-    files: \.py$
-- repo: https://github.com/prettier/prettier.git
-  sha: 1.14.0
-  hooks:
-  - id: prettier
-    files: \.(css|less|scss|ts|tsx|graphql|gql|js|jsx|md)$
+  - repo: https://github.com/pre-commit/pre-commit-hooks.git
+    rev: v1.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+  - repo: https://github.com/ambv/black.git
+    rev: 25.1.0
+    hooks:
+      - id: black
+        entry: black -l 120 -t py311
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        files: \.py$
+  - repo: https://github.com/prettier/prettier.git
+    rev: 1.14.0
+    hooks:
+      - id: prettier
+        files: \.(css|less|scss|ts|tsx|graphql|gql|js|jsx|md)$

--- a/integration_test/statictest/static/milligram.css
+++ b/integration_test/statictest/static/milligram.css
@@ -612,5 +612,3 @@ img {
 .float-right {
   float: right;
 }
-
-/*# sourceMappingURL=milligram.css.map */

--- a/integration_test/statictest/tests.py
+++ b/integration_test/statictest/tests.py
@@ -36,14 +36,21 @@ class CollectStaticTest(SimpleTestCase):
             self.assertFileNotExist(self.temp_dir_path / file)
 
     def assertManifestStaticFiles(self):
-        for file in ["milligram.965a961f3962.css", "system.0177d7f30ce9.js", "speaker.5a6001289b0f.svg"]:
+        for file in [
+            "milligram.e824f9df03b0.css",
+            "system.0177d7f30ce9.js",
+            "speaker.5a6001289b0f.svg",
+        ]:
             self.assertFileExist(self.temp_dir_path / file)
             self.assertFileExist(self.temp_dir_path / (file + ".gz"))
             self.assertFileExist(self.temp_dir_path / (file + ".br"))
 
         self.assertFileExist(self.temp_dir_path / "not_compressed.9517ee88fcaa.txt")
 
-        for file in ["not_compressed.9517ee88fcaa.txt.gz", "not_compressed.9517ee88fcaa.txt.br"]:
+        for file in [
+            "not_compressed.9517ee88fcaa.txt.gz",
+            "not_compressed.9517ee88fcaa.txt.br",
+        ]:
             self.assertFileNotExist(self.temp_dir_path / file)
 
         for file in ("too_small.1fad53895b9b.js.gz", "too_small.1fad53895b9b.js.br"):
@@ -51,7 +58,7 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_static(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_ROOT=self.temp_dir.name,
         ):
@@ -61,13 +68,19 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_manifest(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedManifestStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedManifestStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_ROOT=self.temp_dir.name,
         ):
             call_command("collectstatic", interactive=False, verbosity=0)
 
-            for file in ["milligram.css", "system.js", "not_compressed.txt", "speaker.svg", "staticfiles.json"]:
+            for file in [
+                "milligram.css",
+                "system.js",
+                "not_compressed.txt",
+                "speaker.svg",
+                "staticfiles.json",
+            ]:
                 self.assertFileExist(self.temp_dir_path / file)
                 self.assertFileNotExist(self.temp_dir_path / (file + ".gz"))
                 self.assertFileNotExist(self.temp_dir_path / (file + ".br"))
@@ -76,7 +89,7 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_only_gz(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_COMPRESS_METHODS=["gz"],
             STATIC_ROOT=self.temp_dir.name,
@@ -92,7 +105,7 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_changed_file_ext(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_COMPRESS_FILE_EXTS=("js", "css"),
             STATIC_ROOT=self.temp_dir.name,
@@ -108,7 +121,7 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_empty_file_ext(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_COMPRESS_FILE_EXTS=[],
             STATIC_ROOT=self.temp_dir.name,
@@ -121,7 +134,7 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_not_keep_original(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_COMPRESS_KEEP_ORIGINAL=False,
             STATIC_ROOT=self.temp_dir.name,
@@ -134,7 +147,7 @@ class CollectStaticTest(SimpleTestCase):
 
     def test_collectstatic_with_zlib(self):
         with self.settings(
-            STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+            STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
             STATIC_COMPRESS_MIN_SIZE_KB=1,
             STATIC_COMPRESS_METHODS=["gz+zlib", "br"],
             STATIC_ROOT=self.temp_dir.name,
@@ -146,7 +159,7 @@ class CollectStaticTest(SimpleTestCase):
     def test_collectstatic_twice_replace(self):
         with tempfile.TemporaryDirectory() as static_dir:
             with self.settings(
-                STATICFILES_STORAGE="static_compress.storage.CompressedStaticFilesStorage",
+                STORAGES={"staticfiles": {"BACKEND": "static_compress.storage.CompressedStaticFilesStorage"}},
                 STATIC_COMPRESS_MIN_SIZE_KB=1,
                 STATIC_COMPRESS_METHODS=["gz+zlib"],
                 STATIC_ROOT=self.temp_dir.name,


### PR DESCRIPTION
I use django-static-compress in a project and noticed a static file that dropped below the STATIC_COMPRESS_MIN_SIZE_KB did not seam to update after using collectstatic, because compressed files would not get updated or deleted when the origin file dropped below  STATIC_COMPRESS_MIN_SIZE_KB.
My fix deletes compressed files if the origin files is below  STATIC_COMPRESS_MIN_SIZE_KB.
I also updated the tests to be django 5.1 compatible.