### PR TITLE
Fix manifest path selection when processing static files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix manifest path selection for compressed files by preferring `hashed_files` mappings and falling back to `hashed_name` or original paths when needed.
 
 ## [2.1.0] - 2025-02-21
 ## Fixed

--- a/static_compress/mixin.py
+++ b/static_compress/mixin.py
@@ -122,6 +122,8 @@ class CompressMixin:
                     file.seek(0)
 
     def _get_dest_path(self, path):
+        if hasattr(self, "hashed_files"):
+            return self.hashed_files.get(path, path)
         if hasattr(self, "hashed_name"):
             return self.hashed_name(path)
 


### PR DESCRIPTION
This change prefers the hashed_files mapping created during collectstatic to resolve destination paths, falling back to hashed_name and the original path only when that mapping is not available. This avoids recomputing hashes mid-run, which in our case caused missing-file errors with Manifest storage even when compression was disabled.