### PR TITLE
Align Python/Django support metadata and dependency minimums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump Python support metadata to 3.10+.
+- Align Django minimum version with supported Python range.
+
+### Security
+- Raise minimum Brotli and Zopfli versions (Brotli>=1.2.0, zopfli>=0.3.0).
 
 ## [2.1.0] - 2025-02-21
 ## Fixed

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["Django>=4.2", "Brotli~=1.0.9", "zopfli~=0.1.8"],
+    install_requires=["Django>=4.2", "Brotli>=1.2.0,<2.0.0", "zopfli>=0.3.0,<0.5.0"],
     python_requires=">=3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["Django", "Brotli~=1.0.9", "zopfli~=0.1.8"],
+    install_requires=["Django>=4.2", "Brotli~=1.0.9", "zopfli~=0.1.8"],
     python_requires=">=3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
     install_requires=["Django", "Brotli~=1.0.9", "zopfli~=0.1.8"],
+    python_requires=">=3.10",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
@@ -21,9 +22,11 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Pre-processors",
     ],
 )


### PR DESCRIPTION
In this PR I updated the project metadata and dependency minimums so everything is aligned with the current support policy. Specifically, Python support is now clearly declared as 3.10+, Django is aligned to that range with a minimum of 4.2, and the Brotli/Zopfli minimum versions were raised to Brotli>=1.2.0 and zopfli>=0.3.0. The Brotli update is also motivated by the CVE-2025-6176 fix, so this is not just a compatibility cleanup but also a security baseline improvement. I also documented these updates in CHANGELOG.md under Unreleased so the release notes reflect the reason and scope of the change.